### PR TITLE
Generators for custom pipelines demo

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,12 +5,14 @@
   <!-- Microsoft.Extensions -->
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Polly" Version="7.2.3" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />

--- a/src/Resilience.DependencyInjection/Example/Generated/SimplePipelineExtensions.cs
+++ b/src/Resilience.DependencyInjection/Example/Generated/SimplePipelineExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Resilience.Strategies.Retry;
+using Resilience.Strategies.Timeout;
+
+namespace Resilience.DependencyInjection.Example.Generated;
+
+internal static class SimplePipelineExtensions
+{
+    public static IServiceCollection AddSimplePipeline(this IServiceCollection services, Action<SimplePipelineOptions>? configure = null, IConfigurationSection? section = null)
+    {
+        var builder = services.AddOptions<SimplePipelineOptions>("SimplePipeline");
+
+        if (configure != null)
+        {
+            builder.Configure(configure);
+        }
+
+        if (section != null)
+        {
+            builder.Bind(section);
+        }
+
+        services.AddResilienceStrategy("SimplePipeline", (serviceProvider, builder) =>
+        {
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<SimplePipelineOptions>>().Get("SimplePipeline");
+
+            builder.AddTimeout(options.TotalTimeout);
+            builder.AddRetry(options.Retry);
+            builder.AddTimeout(options.AttemptTimeout);
+        });
+
+        return services;
+    }
+}

--- a/src/Resilience.DependencyInjection/Example/Generated/SimplePipelineExtensions.cs
+++ b/src/Resilience.DependencyInjection/Example/Generated/SimplePipelineExtensions.cs
@@ -14,7 +14,8 @@ using Resilience.Strategies.Timeout;
 
 namespace Resilience.DependencyInjection.Example.Generated;
 
-internal static class SimplePipelineExtensions
+// Generated Code
+internal static partial class SimplePipelineExtensions
 {
     public static IServiceCollection AddSimplePipeline(this IServiceCollection services, Action<SimplePipelineOptions>? configure = null, IConfigurationSection? section = null)
     {

--- a/src/Resilience.DependencyInjection/Example/SimplePipelineOptions.cs
+++ b/src/Resilience.DependencyInjection/Example/SimplePipelineOptions.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Resilience.Strategies.Retry;
+using Resilience.Strategies.Timeout;
+
+namespace Resilience.DependencyInjection.Example;
+
+[ResilienceStrategy]
+public class SimplePipelineOptions
+{
+    public TimeoutStrategyOptions TotalTimeout { get; set; } = new();
+
+    public RetryStrategyOptions Retry { get; set; } = new();
+
+    public TimeoutStrategyOptions AttemptTimeout { get; set; } = new();
+}

--- a/src/Resilience.DependencyInjection/Resilience.DependencyInjection.csproj
+++ b/src/Resilience.DependencyInjection/Resilience.DependencyInjection.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Resilience.DependencyInjection</AssemblyName>
@@ -7,14 +7,19 @@
   <ItemGroup>
     <InternalsVisibleToDynamicProxyGenAssembly2 Remove="IResilienceStrategyProvider.cs" />
     <InternalsVisibleToDynamicProxyGenAssembly2 Remove="ResilienceServiceCollectionExtensions.cs" />
+    <InternalsVisibleToDynamicProxyGenAssembly2 Remove="ResilienceStrategyAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Resilience.Strategies\Resilience.Strategies.csproj" />
     <ProjectReference Include="..\Resilience\Resilience.csproj" />
   </ItemGroup>
 

--- a/src/Resilience.DependencyInjection/ResilienceStrategyAttribute.cs
+++ b/src/Resilience.DependencyInjection/ResilienceStrategyAttribute.cs
@@ -1,0 +1,5 @@
+﻿namespace Resilience.DependencyInjection;
+
+public class ResilienceStrategyAttribute : Attribute
+{
+}


### PR DESCRIPTION
This demo demonstrates how generators can be used to generate resilience pipeline:

``` csharp 
[ResilienceStrategy]
public class SimplePipelineOptions
{
    public TimeoutStrategyOptions TotalTimeout { get; set; } = new();

    public RetryStrategyOptions Retry { get; set; } = new();

    public TimeoutStrategyOptions AttemptTimeout { get; set; } = new();
}
```

- First, you need to define options that represent the pipeline.
- Annotate those with `[ResilienceStrategy]` attribute.

The generator will generate the extensions that help you easily integrate with DI:


``` csharp
IServiceCollection services = ... ;

// generated extension
services.AddSimplePipeline();

// or configure options
services.AddSimplePipeline(configure: options => ... );

// or bind from IConfigurationSection
services.AddSimplePipeline(section: configuration.GetSection("my-section"));
``` 

